### PR TITLE
feat: hide multiple fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.6.0] - 2025-04-13
+
+### Added
+- **Support for multiple fields in one call**
+  - Introduced `Umbra.fields()` for hiding multiple sections.
+
 ## [1.5.1] - 2025-04-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -39,8 +39,10 @@
   - [Comment Box](#comment-box)
   - [Sidebar](#sidebar)
   - [Form Fields](#form-fields)
+    - [Hiding a Specific Field](#hiding-a-specific-field)
+    - [Hiding Multiple Fields](#hiding-multiple-fields)
   - [Form Sections](#form-sections)
-    - [Hiding a One Off Section](#hiding-a-one-off-section)
+    - [Hiding Specific Section](#hiding-specific-section)
     - [Hiding Multiple Sections](#hiding-multiple-sections)
   - [Workspace](#workspace)
     - [Workspace Sidebar](#workspace-sidebar)
@@ -267,6 +269,7 @@ frappe.ui.form.on('YourDoctype', {
 
 ### Form Fields
 
+#### Hiding a Specific Field
 ```javascript
 Umbra.field.name_of_desired_field()
 ```
@@ -282,9 +285,29 @@ Umbra.field.my_field({
 });
 
 ```
+
+#### Hiding Multiple Fields
+```javascript
+Umbra.fields({ fields: ["middle_name", "salary"] });
+```
+
+Hide multiple fields "middle_name" and "salary" with conditional logic
+and the current user is not the owner/creator of the form.
+
+```javascript
+Umbra.fields({
+  fields: ["middle_name", "salary"],
+  conditional: (frm) => {
+    return frappe.session.user !== frm.doc.owner
+  },
+  debug: true
+});
+
+```
+
 ### Form Sections
 
-#### Hiding a One Off Section
+#### Hiding Specific Section
 ```javascript
 Umbra.section.name_of_desired_section()
 ```

--- a/umbra.js
+++ b/umbra.js
@@ -4,7 +4,7 @@
  * Hides things.
  * Umbra simplifies hiding elements we might commonly hide in Frappe.
  * 
- * @version 1.5.1
+ * @version 1.6.0
  *
  * @module Umbra
  */
@@ -589,6 +589,65 @@ const Umbra = (function () {
 	})
 
 	// ----------------------------
+	// Form Fields
+	// ----------------------------
+	/**
+	 * Hides specified Fields on a frappe form.
+	 *
+	 * If the conditional returns false or the user has any of the bypass roles (permissions), no action is taken.
+	 * Otherwise, the hides are hidden.
+	 *
+	 * @param {Object} props - Configuration object for hiding fields.
+	 * @param {string[]} props.fields - The fields to hide. Provide multiple fields names as an array.
+	 * @param {Function} [props.conditional] - Optional flag to enable conditional hiding logic.
+	 * @param {string[]} [props.permissions] - Optional array of role names; if the user has any of these roles, field hiding will be bypassed.
+	 * @param {boolean} [props.debug=false] - Optional flag to enable debug logging.
+	 *
+	 * @example
+	 * // Hide multiple fields "middle_name" and "salary" with conditional logic
+	 * Umbra.fields({ fields: ["middle_name", "salary"], conditional: (frm) => { return frappe.session.user !== frm.doc.owner }, debug: true });
+	 *
+	 * @returns {void}
+	 */
+	const fields = (props = {}) => {
+		const { fields, conditional = () => { return true }, permissions, debug } = props
+
+		if (typeof Utils === 'undefined') {
+			if (debug && getEnvironment() === "development") {
+				console.warn("Umbra.fields: Utils module is not available.\nhttps://github.com/karotkriss/Utils");
+				frappe.show_alert("Utils module is missing. Please include Utils.js.");
+			}
+			return;
+		}
+
+		if (!props || typeof props !== "object") {
+			if (debug && getEnvironment() === "development") console.error("Umbra.fields expects an object as an argument.");
+			return;
+		}
+
+		if (Array.isArray(permissions) && userHasRole(permissions)) {
+			if (debug && getEnvironment() === "development") {
+				console.debug(`Umbra.fields(): User has bypass role, skipping section hiding.`);
+			}
+			return;
+		}
+
+
+		if (typeof conditional !== "function") {
+			if (debug && getEnvironment() === "development") {
+				console.debug(`Umbra.fields(): 'conditional' must be a function.`);
+			}
+			return;
+		}
+
+		frappe.utilsPlus.hideFields({
+			fields: fields,
+			conditional: conditional,
+			debug: debug
+		});
+	};
+
+	// ----------------------------
 	// Form Section
 	// ----------------------------
 	/**
@@ -972,6 +1031,7 @@ const Umbra = (function () {
 		comment: comment,
 		sidebar: sidebar,
 		field: field,
+		fields: fields,
 		section: section,
 		sections: sections,
 		workspace: workspace,

--- a/umbra.js
+++ b/umbra.js
@@ -595,7 +595,7 @@ const Umbra = (function () {
 	 * Hides specified Fields on a frappe form.
 	 *
 	 * If the conditional returns false or the user has any of the bypass roles (permissions), no action is taken.
-	 * Otherwise, the hides are hidden.
+	 * Otherwise, the fields are hidden.
 	 *
 	 * @param {Object} props - Configuration object for hiding fields.
 	 * @param {string[]} props.fields - The fields to hide. Provide multiple fields names as an array.
@@ -746,7 +746,7 @@ const Umbra = (function () {
 	 * Hides specified sections on a frappe form.
 	 *
 	 * If the conditional returns false or the user has any of the bypass roles (permissions), no action is taken.
-	 * Otherwise, the hides are hidden.
+	 * Otherwise, the sections are hidden.
 	 *
 	 * @param {Object} props - Configuration object for hiding sections.
 	 * @param {string[]} props.sections - The sections to hide. Provide multiple section names as an array.

--- a/umbra.js
+++ b/umbra.js
@@ -620,14 +620,14 @@ const Umbra = (function () {
 			return;
 		}
 
-		if (!props || typeof props !== "object") {
-			if (debug && getEnvironment() === "development") console.error("Umbra.fields expects an object as an argument.");
+		if (!fields || !Array.isArray(fields)) {
+			if (debug && getEnvironment() === "development") console.error("Umbra.fields expects 'fields' to be an array.");
 			return;
 		}
 
 		if (Array.isArray(permissions) && userHasRole(permissions)) {
 			if (debug && getEnvironment() === "development") {
-				console.debug(`Umbra.fields(): User has bypass role, skipping section hiding.`);
+				console.debug(`Umbra.fields(): User has bypass role, skipping field hiding.`);
 			}
 			return;
 		}


### PR DESCRIPTION
## [1.6.0] - 2025-04-13

### Added
- **Support for multiple fields in one call**
  - Introduced `Umbra.fields()` for hiding multiple sections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new capability for dynamically hiding multiple fields simultaneously based on user roles and conditions, now part of the latest release (v1.6.0).

- **Documentation**
  - Enhanced guidance with additional sections covering how to hide individual fields and multiple fields, along with updated section titles for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->